### PR TITLE
fix(deps): bump nanoid to close GHSA-mwcw-c2x4-8c55

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,8 +575,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.0.7:
-    resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -821,7 +821,7 @@ snapshots:
       '@internationalized/date': 3.5.4
       dequal: 2.0.3
       focus-trap: 7.5.4
-      nanoid: 5.0.7
+      nanoid: 5.1.16
       svelte: 5.56.8
 
   '@oxc-project/types@0.143.0': {}
@@ -1177,7 +1177,7 @@ snapshots:
 
   nanoid@3.3.17: {}
 
-  nanoid@5.0.7: {}
+  nanoid@5.1.16: {}
 
   node-html-parser@9.0.1:
     dependencies:


### PR DESCRIPTION
Bumps `nanoid` 5.0.7 -> 5.1.16, closing **GHSA-mwcw-c2x4-8c55** (moderate, "Predictable results in nanoid generation when given non-integer values", affects `>= 4.0.0, < 5.0.9`).

Lockfile-only change: `@melt-ui/svelte@0.86.6` declares `nanoid: ^5.0.4`, so 5.1.16 is already inside the allowed range. The lockfile had just gone stale — no manifest change, no override needed.

## Why nothing caught this

`pnpm audit` reports it. Dependabot does not, and the reason is not a gap in the advisory data:

- the advisory is live in the GitHub Advisory Database, not withdrawn, npm ecosystem, `>= 4.0.0, < 5.0.9`
- nanoid 5.0.7 is present in the repository dependency graph

The alert exists — it was **dismissed on 2025-01-03 with reason `fix_started`**, and a dismissed alert never re-fires. The fix was apparently never finished, so the vulnerable version sat in the lockfile for 19 months with a green Dependabot dashboard.

Worth keeping in mind for the auto-merge setup: `dismissed` alerts are invisible to it. Running `pnpm audit` in CI would have caught this independently.

## Verification

- `pnpm audit` -> "No known vulnerabilities found" (was 1 moderate)
- `pnpm build` passes
- `npx svelte-check` -> 0 errors
